### PR TITLE
Small fix for nest device tags breaking inserts

### DIFF
--- a/home_collectors/0/nest_collector.py
+++ b/home_collectors/0/nest_collector.py
@@ -41,7 +41,7 @@ def collect_all_devices(napi):
         printmetric("num_thermostats", ts, structure.num_thermostats, tags)
 
         for device in structure.thermostats:
-            tags = {"structure":structure.name, "device":device.name}
+            tags = {"structure":structure.name, "device":device.name.replace('(', '').replace(')', '')}
             metric_prefix = "thermostat."
             printmetric(metric_prefix + "temperature", ts, device.temperature, tags)
             printmetric(metric_prefix + "humidity", ts, device.humidity, tags)
@@ -63,7 +63,7 @@ def collect_all_devices(napi):
             printmetric(metric_prefix + "hvac_state", ts, hvac_state_val, tags)
 
         for device in structure.smoke_co_alarms:
-            tags = {"structure":structure.name, "device":device.name}
+            tags = {"structure":structure.name, "device":device.name.replace('(', '').replace(')', '')}
             metric_prefix = "smoke_co_alarm."
 
             status_map = {


### PR DESCRIPTION
I noticed that when I tagged a device, it introduced a set of parentheses into the data, which promptly broke the TSDB insert.  I simply stripped them out (escaping didn't seem to work).